### PR TITLE
Unpin pyflakes version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,6 @@ coveralls = "*"
 mypy = "*"
 pylama = {extras = ["all"], version = "*"}
 pytest = "*"
-pyflakes = "==2.4.0"
 
 [requires]
 python_version = "3.10"


### PR DESCRIPTION
### What does this PR do?

Removes pyflakes from Pipfile, unpinning the version and letting it be handled as a Pylama subdependency.

### Helpful background context

Pylama had a bug with the latest version of pyflakes, so we had to pin the pyflakes version to an older one in order for the linters to work. Pylama has released a version with a fix so we can unpin pyflakes now.

### How can a reviewer manually see the effects of these changes?

Run `make install` and confirm that the installed pyflakes version is 2.5.0 and `make lint` works as expected (or just review the Github actions log for the same info).

### Includes new or updated dependencies?

YES

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
